### PR TITLE
Clear the key after processed in 'pressKey'.

### DIFF
--- a/src/lib/varvara/devices/controller.zig
+++ b/src/lib/varvara/devices/controller.zig
@@ -62,6 +62,8 @@ pub const Controller = struct {
         dev.storePort(u8, cpu, ports.key, key);
 
         try dev.invokeVector(cpu);
+
+        dev.storePort(u8, cpu, ports.key, 0);
     }
 
     pub fn pressButtons(dev: *@This(), cpu: *Cpu, buttons: ButtonFlags, player: u2) !void {


### PR DESCRIPTION
Otherwise the key will be fired again when release a button (eg: press 'a', then press 'ctrl', release 'ctrl' will fire 2 'a').

Can be tested in the left editor.